### PR TITLE
Add event emitter to ImageUrlSource

### DIFF
--- a/src/NetworkError.js
+++ b/src/NetworkError.js
@@ -19,7 +19,10 @@ var inherits = require('./util/inherits');
 
 // Class used to distinguish network failures from other kinds of errors.
 function NetworkError() {
-  this.constructor.super_.apply(this, arguments);
+  const superInst = this.constructor.super_.apply(this, arguments);
+
+  // Explicitly apply message from error as it can't be accessed otherwise
+  this.message = superInst.message;
 }
 
 inherits(NetworkError, Error);

--- a/src/sources/ImageUrl.js
+++ b/src/sources/ImageUrl.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+var eventEmitter = require('minimal-event-emitter');
 var NetworkError = require('../NetworkError');
 var WorkPool = require('../collections/WorkPool');
 var chain = require('../util/chain');
@@ -86,6 +87,7 @@ ImageUrlSource.prototype.loadAsset = function(stage, tile, done) {
         if (err instanceof NetworkError) {
           // If a network error occurred, wait before retrying.
           retryMap[url] = clock();
+          self.emit('networkError', asset, err);
         }
         done(err, tile);
       } else {
@@ -200,5 +202,6 @@ function propertyRegExp(property) {
   return new RegExp(regExpStr, 'g');
 }
 
+eventEmitter(ImageUrlSource);
 
 module.exports = ImageUrlSource;


### PR DESCRIPTION
So we can receive the NetworkError event externally and check which image failed to load.